### PR TITLE
Specify a distinct base package for the model-server example

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -9,7 +9,6 @@
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
-            <option value="$PROJECT_DIR$/dashboard" />
             <option value="$PROJECT_DIR$/mps" />
             <option value="$PROJECT_DIR$/mps/solutions" />
             <option value="$PROJECT_DIR$/mps/solutions/University.Schedule.api" />

--- a/rest-api-model-server/build.gradle.kts
+++ b/rest-api-model-server/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     testImplementation("io.rest-assured:rest-assured")
 }
 
-val basePackage = "org.modelix.sample"
+val basePackage = "org.modelix.sample.restapimodelserver"
 
 val openApiFile = layout.projectDirectory.file("../openapi/openapi.yaml")
 
@@ -38,6 +38,7 @@ openApiGenerate {
     generatorName.set("kotlin-server")
     inputSpec.set(openApiFile.toString())
     outputDir.set("$buildDir/openapi-generator")
+    packageName.set(basePackage)
     apiPackage.set(basePackage)
     modelPackage.set(basePackage)
     configOptions.set(

--- a/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/Api.kt
+++ b/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/Api.kt
@@ -1,4 +1,4 @@
-package org.modelix.sample
+package org.modelix.sample.restapimodelserver
 
 import University.Schedule.structure.Courses
 import University.Schedule.structure.Rooms

--- a/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/LanguageConfig.kt
+++ b/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/LanguageConfig.kt
@@ -1,4 +1,4 @@
-package org.modelix.sample
+package org.modelix.sample.restapimodelserver
 
 import University.Schedule.api.gen.University_Schedule
 import University.Schedule.api.gen.jetbrains_mps_lang_core

--- a/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/ModelClientConfiguration.kt
+++ b/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/ModelClientConfiguration.kt
@@ -1,4 +1,4 @@
-package org.modelix.sample
+package org.modelix.sample.restapimodelserver
 
 import io.smallrye.config.ConfigMapping
 import io.smallrye.config.WithDefault

--- a/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/ModelClientProducer.kt
+++ b/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/ModelClientProducer.kt
@@ -1,4 +1,4 @@
-package org.modelix.sample
+package org.modelix.sample.restapimodelserver
 
 import org.modelix.model.client.ReplicatedRepository
 import org.modelix.model.client.RestWebModelClient


### PR DESCRIPTION
Avoid polluting the general sample package namespace by moving the Quarkus example in a sub-package.