### PR TITLE
Update notifications in the model-server example

### DIFF
--- a/rest-api-model-server/build.gradle.kts
+++ b/rest-api-model-server/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation("io.quarkus:quarkus-kotlin")
     implementation("io.quarkus:quarkus-resteasy-reactive-jackson")
     implementation("io.quarkus:quarkus-smallrye-openapi")
+    implementation("io.quarkus:quarkus-websockets")
     implementation("io.ktor:ktor-client-core:$ktor_version")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("io.quarkus:quarkus-arc")

--- a/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/Api.kt
+++ b/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/Api.kt
@@ -68,29 +68,6 @@ class Api(private val repo: ReplicatedRepository) : DefaultApi {
         }
     }
 
-    /**
-     * A Kotlin extension function to convert a model lecture to its REST representation enforced by the generated
-     * data class [Lecture].
-     */
-    private fun University.Schedule.structure.Lecture.toRest() = Lecture(
-        lectureRef = INodeReferenceSerializer.serialize(this.reference),
-        name = this.properties.name ?: "",
-        description = this.properties.description ?: "",
-        maxParticipants = this.properties.maxParticipants ?: 0,
-        room = INodeReferenceSerializer.serialize(this.references.room.reference),
-    )
-
-    /**
-     * A Kotlin extension function to convert a model room to its REST representation enforced by the generated
-     * data class [Room].
-     */
-    private fun University.Schedule.structure.Room.toRest() = Room(
-        roomRef = INodeReferenceSerializer.serialize(this.reference),
-        name = this.properties.name ?: "",
-        maxPlaces = this.properties.maxPlaces ?: 0,
-        hasRemoteEquipment = this.properties.hasRemoteEquipment ?: false
-    )
-
     override fun getLectureByRef(lectureRef: String): Lecture = executeRead { area ->
         val node = resolveRef(lectureRef, area)
         ensureIsDesiredConcept<LectureConcept>(node, lectureRef)
@@ -106,13 +83,11 @@ class Api(private val repo: ReplicatedRepository) : DefaultApi {
     }
 
     override fun listLectures(): LectureList = executeRead { area ->
-        val courses = allModelRoots(area).first { it is Courses }
-        LectureList((courses.children as Courses.Children).lectures.map { it.toRest() })
+        Courses(allModelRoots(area).first { it is Courses }.iNode).toRest()
     }
 
     override fun listRooms(): RoomList = executeRead { area ->
-        val rooms = allModelRoots(area).first { it is Rooms }
-        RoomList((rooms.children as Rooms.Children).rooms.map { it.toRest() })
+        Rooms(allModelRoots(area).first { it is Rooms }.iNode).toRest()
     }
 
 }

--- a/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/Api.kt
+++ b/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/Api.kt
@@ -72,22 +72,22 @@ class Api(private val repo: ReplicatedRepository) : DefaultApi {
         val node = resolveRef(lectureRef, area)
         ensureIsDesiredConcept<LectureConcept>(node, lectureRef)
 
-        University.Schedule.structure.Lecture(node).toRest()
+        University.Schedule.structure.Lecture(node).toJson()
     }
 
     override fun getRoomByRef(roomRef: String): Room = executeRead { area ->
         val node = resolveRef(roomRef, area)
         ensureIsDesiredConcept<RoomConcept>(node, roomRef)
 
-        University.Schedule.structure.Room(node).toRest()
+        University.Schedule.structure.Room(node).toJson()
     }
 
     override fun listLectures(): LectureList = executeRead { area ->
-        Courses(allModelRoots(area).first { it is Courses }.iNode).toRest()
+        Courses(allModelRoots(area).first { it is Courses }.iNode).toJson()
     }
 
     override fun listRooms(): RoomList = executeRead { area ->
-        Rooms(allModelRoots(area).first { it is Rooms }.iNode).toRest()
+        Rooms(allModelRoots(area).first { it is Rooms }.iNode).toJson()
     }
 
 }

--- a/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/Serialization.kt
+++ b/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/Serialization.kt
@@ -30,3 +30,15 @@ fun University.Schedule.structure.Room.toRest() = Room(
 fun Rooms.toRest() = RoomList(this.children.rooms.map { it.toRest() })
 
 fun Courses.toRest() = LectureList(this.children.lectures.map { it.toRest() })
+
+enum class WhatChanged {
+    ROOM,
+    ROOM_LIST,
+    LECTURE,
+    LECTURE_LIST
+}
+
+data class ChangeNotification(
+    val whatChanged: WhatChanged,
+    val change: Any
+)

--- a/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/Serialization.kt
+++ b/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/Serialization.kt
@@ -1,0 +1,32 @@
+package org.modelix.sample.restapimodelserver
+
+import University.Schedule.structure.Courses
+import University.Schedule.structure.Rooms
+import org.modelix.model.lazy.INodeReferenceSerializer
+
+/**
+ * A Kotlin extension function to convert a model lecture to its REST representation enforced by the generated
+ * data class [Lecture].
+ */
+fun University.Schedule.structure.Lecture.toRest() = Lecture(
+    lectureRef = INodeReferenceSerializer.serialize(this.reference),
+    name = this.properties.name ?: "",
+    description = this.properties.description ?: "",
+    maxParticipants = this.properties.maxParticipants ?: 0,
+    room = INodeReferenceSerializer.serialize(this.references.room.reference),
+)
+
+/**
+ * A Kotlin extension function to convert a model room to its REST representation enforced by the generated
+ * data class [Room].
+ */
+fun University.Schedule.structure.Room.toRest() = Room(
+    roomRef = INodeReferenceSerializer.serialize(this.reference),
+    name = this.properties.name ?: "",
+    maxPlaces = this.properties.maxPlaces ?: 0,
+    hasRemoteEquipment = this.properties.hasRemoteEquipment ?: false
+)
+
+fun Rooms.toRest() = RoomList(this.children.rooms.map { it.toRest() })
+
+fun Courses.toRest() = LectureList(this.children.lectures.map { it.toRest() })

--- a/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/Serialization.kt
+++ b/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/Serialization.kt
@@ -5,10 +5,10 @@ import University.Schedule.structure.Rooms
 import org.modelix.model.lazy.INodeReferenceSerializer
 
 /**
- * A Kotlin extension function to convert a model lecture to its REST representation enforced by the generated
+ * A Kotlin extension function to convert a model lecture to its JSON representation enforced by the generated
  * data class [Lecture].
  */
-fun University.Schedule.structure.Lecture.toRest() = Lecture(
+fun University.Schedule.structure.Lecture.toJson() = Lecture(
     lectureRef = INodeReferenceSerializer.serialize(this.reference),
     name = this.properties.name ?: "",
     description = this.properties.description ?: "",
@@ -17,19 +17,19 @@ fun University.Schedule.structure.Lecture.toRest() = Lecture(
 )
 
 /**
- * A Kotlin extension function to convert a model room to its REST representation enforced by the generated
+ * A Kotlin extension function to convert a model room to its JSON representation enforced by the generated
  * data class [Room].
  */
-fun University.Schedule.structure.Room.toRest() = Room(
+fun University.Schedule.structure.Room.toJson() = Room(
     roomRef = INodeReferenceSerializer.serialize(this.reference),
     name = this.properties.name ?: "",
     maxPlaces = this.properties.maxPlaces ?: 0,
     hasRemoteEquipment = this.properties.hasRemoteEquipment ?: false
 )
 
-fun Rooms.toRest() = RoomList(this.children.rooms.map { it.toRest() })
+fun Rooms.toJson() = RoomList(this.children.rooms.map { it.toJson() })
 
-fun Courses.toRest() = LectureList(this.children.lectures.map { it.toRest() })
+fun Courses.toJson() = LectureList(this.children.lectures.map { it.toJson() })
 
 enum class WhatChanged {
     ROOM,

--- a/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/UpdateSocket.kt
+++ b/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/UpdateSocket.kt
@@ -71,10 +71,10 @@ class UpdateSocket(private val repo: ReplicatedRepository, private val mapper: O
         val node = PNodeAdapter(nodeId, repo.branch)
         area.executeRead {
             when (node.concept) {
-                is RoomConcept -> broadcast(ChangeNotification(WhatChanged.ROOM, Room(node).toRest()))
-                is RoomsConcept -> broadcast(ChangeNotification(WhatChanged.ROOM_LIST, Rooms(node).toRest()))
-                is LectureConcept -> broadcast(ChangeNotification(WhatChanged.LECTURE, Lecture(node).toRest()))
-                is CoursesConcept -> broadcast(ChangeNotification(WhatChanged.LECTURE_LIST, Courses(node).toRest()))
+                is RoomConcept -> broadcast(ChangeNotification(WhatChanged.ROOM, Room(node).toJson()))
+                is RoomsConcept -> broadcast(ChangeNotification(WhatChanged.ROOM_LIST, Rooms(node).toJson()))
+                is LectureConcept -> broadcast(ChangeNotification(WhatChanged.LECTURE, Lecture(node).toJson()))
+                is CoursesConcept -> broadcast(ChangeNotification(WhatChanged.LECTURE_LIST, Courses(node).toJson()))
                 else -> logger.warn("Could not handle change")
             }
         }

--- a/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/UpdateSocket.kt
+++ b/rest-api-model-server/src/main/kotlin/org/modelix/sample/restapimodelserver/UpdateSocket.kt
@@ -1,0 +1,112 @@
+package org.modelix.sample.restapimodelserver
+
+import University.Schedule.structure.Courses
+import University.Schedule.structure.Lecture
+import University.Schedule.structure.Room
+import University.Schedule.structure.Rooms
+import University.Schedule.structure.concepts.CoursesConcept
+import University.Schedule.structure.concepts.LectureConcept
+import University.Schedule.structure.concepts.RoomConcept
+import University.Schedule.structure.concepts.RoomsConcept
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.ktor.util.collections.*
+import org.modelix.model.api.IBranchListener
+import org.modelix.model.api.ITree
+import org.modelix.model.api.ITreeChangeVisitor
+import org.modelix.model.api.PNodeAdapter
+import org.modelix.model.area.PArea
+import org.modelix.model.client.ReplicatedRepository
+import org.slf4j.LoggerFactory
+import javax.enterprise.context.ApplicationScoped
+import javax.websocket.OnClose
+import javax.websocket.OnError
+import javax.websocket.OnOpen
+import javax.websocket.Session
+import javax.websocket.server.ServerEndpoint
+
+@ServerEndpoint("/updates")
+@ApplicationScoped
+class UpdateSocket(private val repo: ReplicatedRepository, private val mapper: ObjectMapper) {
+
+    private val logger = LoggerFactory.getLogger(UpdateSocket::class.java)
+
+    init {
+        repo.branch.addListener(object : IBranchListener {
+            override fun treeChanged(oldTree: ITree?, newTree: ITree) {
+                logger.info("Processing repo change")
+
+                if (oldTree == null) {
+                    logger.info("Ignoring changes because no old tree exited")
+                    return
+                }
+
+                newTree.visitChanges(oldTree, object : ITreeChangeVisitor {
+                    override fun childrenChanged(nodeId: Long, role: String?) {
+                        logger.debug("Children of node changed. [nodeId={}, role={}]", nodeId, role)
+                        handleChange(nodeId)
+                    }
+
+                    override fun containmentChanged(nodeId: Long) {
+                        logger.debug("Containment of node changed. [nodeId={}]", nodeId)
+                        handleChange(nodeId)
+                    }
+
+                    override fun propertyChanged(nodeId: Long, role: String) {
+                        logger.debug("Property of node changed. [nodeId={}, role={}]", nodeId, role)
+                        handleChange(nodeId)
+                    }
+
+                    override fun referenceChanged(nodeId: Long, role: String) {
+                        logger.debug("Reference of node changed. [nodeId={}, role={}]", nodeId, role)
+                        handleChange(nodeId)
+                    }
+
+                })
+            }
+        })
+    }
+
+    private fun handleChange(nodeId: Long) {
+        val area = PArea(repo.branch)
+        val node = PNodeAdapter(nodeId, repo.branch)
+        area.executeRead {
+            when (node.concept) {
+                is RoomConcept -> broadcast(ChangeNotification(WhatChanged.ROOM, Room(node).toRest()))
+                is RoomsConcept -> broadcast(ChangeNotification(WhatChanged.ROOM_LIST, Rooms(node).toRest()))
+                is LectureConcept -> broadcast(ChangeNotification(WhatChanged.LECTURE, Lecture(node).toRest()))
+                is CoursesConcept -> broadcast(ChangeNotification(WhatChanged.LECTURE_LIST, Courses(node).toRest()))
+                else -> logger.warn("Could not handle change")
+            }
+        }
+    }
+
+    private val sessions = ConcurrentSet<Session>()
+
+    private fun broadcast(data: Any) {
+        logger.info("Broadcasting to all sessions. [data={}]", data)
+        val mapped = mapper.writeValueAsString(data)
+        sessions.forEach { session ->
+            logger.debug("Broadcasting to session. [session={}, mapped={}]", session, mapped)
+            session.asyncRemote.sendObject(mapped)
+        }
+    }
+
+    @OnOpen
+    fun onOpen(session: Session) {
+        logger.debug("Opening new session. [session={}]", session)
+        sessions.add(session);
+    }
+
+    @OnClose
+    fun onClose(session: Session) {
+        logger.debug("Closing session regularly. [session={}]", session)
+        sessions.remove(session)
+    }
+
+    @OnError
+    fun onError(session: Session, throwable: Throwable) {
+        logger.warn("Closing session after error. [session={}, throwable={}]", session, throwable, throwable)
+        sessions.remove(session)
+    }
+
+}


### PR DESCRIPTION
Adds a web socket to the quarkus project that exposes information on model changes.

Part of #24 